### PR TITLE
feat: add PR comment step to provide Docker image tags and usage instructions

### DIFF
--- a/.github/workflows/cleanup-pr-images.yml
+++ b/.github/workflows/cleanup-pr-images.yml
@@ -1,0 +1,108 @@
+name: Cleanup PR images
+
+on:
+  pull_request:
+    branches: [ "main" ]
+    types: [closed]
+
+jobs:
+  cleanup-pr-images:
+    name: Cleanup GHCR images for merged PR
+    runs-on: ubuntu-latest
+    if: ${{ github.event.pull_request.merged == true }}
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Delete GHCR tags for this PR
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const pkgType = 'container';
+            const pkgName = 'freecaster-grid';
+            const prNumber = context.payload.pull_request?.number;
+            if (!prNumber) {
+              core.info('No PR number found; skipping cleanup');
+              return;
+            }
+
+            const tagTargets = [
+              `pr-${prNumber}`,
+              `pr-${prNumber}-x86_64`,
+              `pr-${prNumber}-arm64`
+            ];
+
+            core.info(`Looking for package versions with tags: ${tagTargets.join(', ')}`);
+
+            // Determine if repository owner is an Organization or a User
+            const ownerType = context.payload.repository?.owner?.type || 'User';
+            core.info(`Detected owner '${owner}' type: ${ownerType}`);
+
+            async function listVersions() {
+              if (ownerType === 'Organization') {
+                return await github.paginate(
+                  github.rest.packages.getAllPackageVersionsForPackageOwnedByOrg,
+                  {
+                    org: owner,
+                    package_type: pkgType,
+                    package_name: pkgName,
+                    per_page: 100
+                  }
+                );
+              } else {
+                return await github.paginate(
+                  github.rest.packages.getAllPackageVersionsForPackageOwnedByUser,
+                  {
+                    username: owner,
+                    package_type: pkgType,
+                    package_name: pkgName,
+                    per_page: 100
+                  }
+                );
+              }
+            }
+
+            async function deleteVersion(id) {
+              if (ownerType === 'Organization') {
+                return await github.rest.packages.deletePackageVersionForOrg({
+                  org: owner,
+                  package_type: pkgType,
+                  package_name: pkgName,
+                  package_version_id: id
+                });
+              } else {
+                return await github.rest.packages.deletePackageVersionForUser({
+                  username: owner,
+                  package_type: pkgType,
+                  package_name: pkgName,
+                  package_version_id: id
+                });
+              }
+            }
+
+            const versions = await listVersions();
+
+            const matches = [];
+            for (const v of versions) {
+              const tags = v?.metadata?.container?.tags ?? [];
+              if (tags.some(t => tagTargets.includes(t))) {
+                matches.push({ id: v.id, name: v.name, tags });
+              }
+            }
+
+            if (matches.length === 0) {
+              core.info('No matching package versions found to delete.');
+              return;
+            }
+
+            core.info(`Found ${matches.length} package versions to delete.`);
+
+            for (const m of matches) {
+              try {
+                core.info(`Deleting version id=${m.id} tags=[${m.tags.join(', ')}]`);
+                await deleteVersion(m.id);
+              } catch (err) {
+                core.warning(`Failed to delete version id=${m.id}: ${err.message}`);
+              }
+            }

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -64,6 +64,8 @@ jobs:
     name: Unify Docker manifests
     runs-on: ubuntu-latest
     needs: build-and-push
+    outputs:
+      tags: ${{ steps.meta.outputs.tags }}
     permissions:
       contents: read
       packages: write
@@ -124,3 +126,46 @@ jobs:
           inputs: ${{ steps.meta.outputs.tags }}
           tags: ${{ steps.multiarch-tags.outputs.tags }}
           push: true
+  
+  comment-pr:
+    name: Comment on PR with Docker image info
+    runs-on: ubuntu-latest
+    needs: unify-manifests
+    if: github.event_name == 'pull_request'
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Comment Docker image tags on PR
+        uses: actions/github-script@v7
+        with:
+          script: |
+            // Collect newline-separated tags from previous job output
+            const raw = `${{ needs.unify-manifests.outputs.tags }}`;
+            const tags = raw.split('\n').map(s => s.trim()).filter(Boolean);
+
+            if (tags.length === 0) {
+              core.info('No tags found to comment. Skipping.');
+              return;
+            }
+
+            const list = tags.map(t => `- \`${t}\``).join('\n');
+            const pullExample = `docker pull ${tags[0]}`;
+
+            const body = [
+              'Docker image(s) for this PR are available:',
+              '',
+              list,
+              '',
+              'Try locally:',
+              '```',
+              pullExample,
+              '```'
+            ].join('\n');
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body
+            });

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -87,7 +87,7 @@ jobs:
         with:
           images: ghcr.io/dewyer/freecaster-grid
           tags: |
-            type=raw,value=latest,enabled=${{ github.ref == 'refs/heads/main' }}
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
             type=ref,event=pr
           labels: |
             org.opencontainers.image.source=${{ github.repository }}
@@ -101,7 +101,7 @@ jobs:
           images: ghcr.io/dewyer/freecaster-grid
           flavor: suffix=-x86_64
           tags: |
-            type=raw,value=latest,enabled=${{ github.ref == 'refs/heads/main' }}
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
             type=ref,event=pr
 
       - name: Metadata for arm64
@@ -111,7 +111,7 @@ jobs:
           images: ghcr.io/dewyer/freecaster-grid
           flavor: suffix=-arm64
           tags: |
-            type=raw,value=latest,enabled=${{ github.ref == 'refs/heads/main' }}
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
             type=ref,event=pr
           
       - name: Convert multi-arch tags from newline to comma separated

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -41,7 +41,7 @@ jobs:
           flavor:
             suffix=-${{ matrix.arch }},onlatest=true
           tags: |
-            type=raw,value=latest,enabled=${{ github.ref == 'refs/heads/main' }}
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
             type=ref,event=pr
           labels: |
             org.opencontainers.image.source=${{ github.repository }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -123,8 +123,8 @@ jobs:
       - name: Create and push manifest list
         uses: Noelware/docker-manifest-action@1.0.0
         with:
-          inputs: ${{ steps.meta.outputs.tags }}
-          tags: ${{ steps.multiarch-tags.outputs.tags }}
+          tags: ${{ steps.meta.outputs.tags }}
+          inputs: ${{ steps.multiarch-tags.outputs.tags }}
           push: true
   
   comment-pr:

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -5,6 +5,7 @@ on:
     branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
+    types: [opened, synchronize, reopened]
   workflow_dispatch:
 
 jobs:
@@ -131,7 +132,7 @@ jobs:
     name: Comment on PR with Docker image info
     runs-on: ubuntu-latest
     needs: unify-manifests
-    if: github.event_name == 'pull_request'
+    if: ${{ github.event_name == 'pull_request' }}
     permissions:
       contents: read
       pull-requests: write
@@ -169,3 +170,5 @@ jobs:
               issue_number: context.issue.number,
               body
             });
+
+  


### PR DESCRIPTION
This pull request updates the Docker publishing workflow to improve automation and provide better feedback on pull requests. The most significant change is the addition of a job that automatically comments on pull requests with information about the published Docker image tags, making it easier for contributors and reviewers to find and use the built images.

**Enhancements to Docker publishing workflow:**

* Added an output (`tags`) to the `unify-manifests` job to expose the Docker image tags for use in downstream jobs.

**Pull request feedback automation:**

* Introduced a new `comment-pr` job that, when a pull request is opened, comments on the PR with the available Docker image tags and an example `docker pull` command, improving visibility and usability for contributors.