### PR TITLE
Fix conditions for build_release job execution

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -132,6 +132,8 @@ jobs:
           tag: ${{ needs.gather_info.outputs.new_tag }}
 
   build_release:
+    if: ${{ github.event.inputs.dry_run == 'false' && needs.gather_info.outputs.version_update_needed == 'false'}}
+    needs: gather_info
     name: Build release artifacts on ${{ matrix.arch }}
     runs-on: ${{ matrix.os }}
     strategy:


### PR DESCRIPTION
Ensure the build_release job only runs when specific conditions are met, improving the workflow's efficiency.