### PR TITLE
Fix variable reference for version check in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Check version in Cargo.toml
         shell: bash
         id: check_version
-        run: version_update_needed=$(uv run scripts/check_cargo_version.py ${{ steps.check_version.outputs.version }}) >> "$GITHUB_OUTPUT"
+        run: version_update_needed=$(uv run scripts/check_cargo_version.py ${{ steps.version.outputs.new_version }}) >> "$GITHUB_OUTPUT"
 
   dry_run_release:
     if: ${{ github.event.inputs.dry_run == 'true' }}


### PR DESCRIPTION
Correct the variable reference used in the version check to ensure accurate version updates in the release workflow.